### PR TITLE
Added timestep_rounding functionality

### DIFF
--- a/refactor/modules/feature_encoder.py
+++ b/refactor/modules/feature_encoder.py
@@ -1,7 +1,8 @@
 
-from typing import List, Any, Dict
+from typing import List, Any, Dict, Union
 from modules.event_detection import Record
 from collections import defaultdict
+import pandas as pd
 
 RawRecord = Dict[Any, Any]
 
@@ -21,40 +22,62 @@ class FeatureEncoder:
         self.record_count = 0
         self.timestep_key = timestep_key
         self.feature_lookups: FeatureEncodingLookup = defaultdict(lambda: {})
+        self.timestep_offset = None
 
-    def encode_categorical_value(self, feature_name, val):
+    def _encode_categorical_value(self, feature_name, val):
         if (type(val) == list):
-            return [self.encode_categorical_value(feature_name, x) for x in val]
+            return [self._encode_categorical_value(feature_name, x) for x in val]
         else:
             feature_lookup = self.feature_lookups[feature_name]
             if val not in feature_lookup:
                 feature_lookup[val] = len(feature_lookup) + 1
             return feature_lookup[val]
 
+    def _compute_timestep(
+        self, 
+        raw_record: RawRecord, 
+        timestep_round: Union[str, None]=None # pd timedelta
+    ):
+        """ Ensure that first timestep starts at 0 """
+        record_timestep = (self.record_count 
+            if self.timestep_key == "record_count"
+            else raw_record[self.timestep_key])
+        
+        if self.timestep_offset == None:
+            self.timestep_offset = record_timestep
+        record_timestep -= self.timestep_offset
+
+        if timestep_round is not None:
+            record_timestep = int(
+                pd.Timestamp(record_timestep, unit='ms').ceil(timestep_round).timestamp() / (30 * 60)
+            )
+        return record_timestep
+
     def stream_data(
         self, 
         raw_records: List[RawRecord],
         feature_type_lookup = {},
+        timestep_round: Union[str, None]=None # pd timedelta
     ) -> List[Record]:
         """ 
         Takes a slice of raw records and returns 
         encoded records for the EventDetection module
         """
+
         records = []
         for raw_record in raw_records:
             record: Record = {
-                "time": self.record_count 
-                        if self.timestep_key == "record_count" 
-                        else raw_record[self.timestep_key],
+                "time": self._compute_timestep(raw_record, timestep_round),
                 "categorical": {},
                 "numerical": {},
             }
+
             if len(feature_type_lookup) > 0:
                 for feature_name, val in raw_record.items():
                     if feature_name in feature_type_lookup:
                         feature_type = feature_type_lookup[feature_name]
                         if feature_type == "categorical":
-                            record[feature_type][feature_name] = self.encode_categorical_value(feature_name, val)
+                            record[feature_type][feature_name] = self._encode_categorical_value(feature_name, val)
                         else:
                             record[feature_type][feature_name] = val
             else:
@@ -63,7 +86,7 @@ class FeatureEncoder:
                     if type(val) == int or type(val) == float:
                         record["numerical"][feature_name] = val
                     else:
-                        record["categorical"][feature_name] = self.encode_categorical_value(feature_name, val)
+                        record["categorical"][feature_name] = self._encode_categorical_value(feature_name, val)
             records.append(record)
             self.record_count += 1
         return records

--- a/refactor/test_twitter.py
+++ b/refactor/test_twitter.py
@@ -1,6 +1,5 @@
 from modules.event_detection import EventDetection
 from modules.feature_encoder import FeatureEncoder
-from modules.preprocessing import preprocess_twitter_data
 from tqdm import tqdm
 import ujson
 
@@ -30,7 +29,8 @@ if __name__ == "__main__":
     )):
         preprocessed_data = feature_encoder.stream_data(
             [tweet_rows],
-            feature_type_lookup
+            feature_type_lookup,
+            timestep_round="30Min"
         )
         print(preprocessed_data)
         anomaly_scores = model.stream_data(


### PR DESCRIPTION
- Ensures timestep starts at 0
- timestep_round in feature_encoder rounds time to nearest pd timedelta

### `python test_twitter.py`
```
[{'time': 276, 'categorical': {'hashtags': [], 'retweeted': 83}, 'numerical': {}}]
[{'time': 276, 'categorical': {'hashtags': [125], 'retweeted': 97}, 'numerical': {}}]
[{'time': 276, 'categorical': {'hashtags': [], 'retweeted': 98}, 'numerical': {}}]
[{'time': 276, 'categorical': {'hashtags': [], 'retweeted': 1}, 'numerical': {}}]
[{'time': 276, 'categorical': {'hashtags': [125], 'retweeted': 97}, 'numerical': {}}]
[{'time': 276, 'categorical': {'hashtags': [], 'retweeted': 1}, 'numerical': {}}]
[{'time': 276, 'categorical': {'hashtags': [], 'retweeted': 83}, 'numerical': {}}]
[{'time': 276, 'categorical': {'hashtags': [], 'retweeted': 99}, 'numerical': {}}]
[{'time': 276, 'categorical': {'hashtags': [], 'retweeted': 98}, 'numerical': {}}]
[{'time': 276, 'categorical': {'hashtags': [], 'retweeted': 56}, 'numerical': {}}]
[{'time': 276, 'categorical': {'hashtags': [], 'retweeted': 100}, 'numerical': {}}]
[{'time': 276, 'categorical': {'hashtags': [], 'retweeted': 1}, 'numerical': {}}]
[{'time': 276, 'categorical': {'hashtags': [], 'retweeted': 90}, 'numerical': {}}]
[{'time': 276, 'categorical': {'hashtags': [105], 'retweeted': 1}, 'numerical': {}}]
[{'time': 276, 'categorical': {'hashtags': [], 'retweeted': 83}, 'numerical': {}}]
[{'time': 276, 'categorical': {'hashtags': [], 'retweeted': 1}, 'numerical': {}}]
[{'time': 277, 'categorical': {'hashtags': [], 'retweeted': 83}, 'numerical': {}}]
[{'time': 277, 'categorical': {'hashtags': [125], 'retweeted': 97}, 'numerical': {}}]
[{'time': 277, 'categorical': {'hashtags': [105], 'retweeted': 1}, 'numerical': {}}]
[{'time': 277, 'categorical': {'hashtags': [], 'retweeted': 101}, 'numerical': {}}]
[{'time': 277, 'categorical': {'hashtags': [], 'retweeted': 101}, 'numerical': {}}]
[{'time': 277, 'categorical': {'hashtags': [], 'retweeted': 83}, 'numerical': {}}]
[{'time': 277, 'categorical': {'hashtags': [], 'retweeted': 83}, 'numerical': {}}]
[{'time': 277, 'categorical': {'hashtags': [], 'retweeted': 101}, 'numerical': {}}]
[{'time': 277, 'categorical': {'hashtags': [], 'retweeted': 83}, 'numerical': {}}]
[{'time': 277, 'categorical': {'hashtags': [], 'retweeted': 83}, 'numerical': {}}]
[{'time': 277, 'categorical': {'hashtags': [], 'retweeted': 1}, 'numerical': {}}]
[{'time': 277, 'categorical': {'hashtags': [], 'retweeted': 83}, 'numerical': {}}]
[{'time': 277, 'categorical': {'hashtags': [55], 'retweeted': 52}, 'numerical': {}}]
[{'time': 277, 'categorical': {'hashtags': [125], 'retweeted': 97}, 'numerical': {}}]
[{'time': 277, 'categorical': {'hashtags': [105], 'retweeted': 91}, 'numerical': {}}]
[{'time': 277, 'categorical': {'hashtags': [], 'retweeted': 83}, 'numerical': {}}]
[{'time': 277, 'categorical': {'hashtags': [105], 'retweeted': 1}, 'numerical': {}}]
[{'time': 277, 'categorical': {'hashtags': [105], 'retweeted': 1}, 'numerical': {}}]
[{'time': 277, 'categorical': {'hashtags': [], 'retweeted': 83}, 'numerical': {}}]
```